### PR TITLE
bug fixed: too many labels in obs field

### DIFF
--- a/yomix/__main__.py
+++ b/yomix/__main__.py
@@ -51,7 +51,7 @@ def main():
     argument = args.example
 
     if argument:
-        filearg = Path(__file__).parent / "example" / "pbmc.h5ad"
+        filearg = Path(__file__).parent / "example" / "_meth_test.h5ad"
     else:
         assert (
             args.file is not None
@@ -83,12 +83,14 @@ def main():
         obs_string_init = list(xd.obs.select_dtypes("category").keys())
         all_labels_list = []
         for lbl in obs_string_init:
-            labels = np.array(list(dict.fromkeys(xd.obs[str(lbl)])))
-            all_labels_list += [(str(lbl), str(elt)) for elt in labels]
-            for elt in labels:
-                xd.var["yomix_median_" + str(lbl) + ">>yomix>>" + str(elt)] = -np.ones(
-                    xd.n_vars
-                )
+            # filter labels
+            if yomix.plotting.check_obs_field(xd, str(lbl)):
+                labels = np.array(list(dict.fromkeys(xd.obs[str(lbl)])))
+                all_labels_list += [(str(lbl), str(elt)) for elt in labels]
+                for elt in labels:
+                    xd.var["yomix_median_" + str(lbl) + ">>yomix>>" + str(elt)] = -np.ones(
+                        xd.n_vars
+                    )
         xd.uns["all_labels"] = all_labels_list
 
         def var_mean_values(adata) -> np.ndarray:
@@ -167,7 +169,7 @@ def main():
                         points_bokeh_plot, source_rotmatrix_etc
                     )
 
-                    (select_color_by, hidden_text_label_column, hidden_legend_width) = (
+                    (select_color_by, help_color_by, hidden_text_label_column, hidden_legend_width) = (
                         yomix.plotting.setup_legend(
                             points_bokeh_plot,
                             obs_string,
@@ -291,7 +293,7 @@ def main():
                                     ),
                                     bokeh.layouts.column(
                                         bokeh.layouts.row(
-                                            select_color_by, sample_search_input
+                                            select_color_by, help_color_by, sample_search_input
                                         ),
                                         bokeh.layouts.row(
                                             offset_text_feature_color, bt_open_link
@@ -330,7 +332,7 @@ def main():
                                     ),
                                     bokeh.layouts.column(
                                         bokeh.layouts.row(
-                                            select_color_by, sample_search_input
+                                            select_color_by, help_color_by, sample_search_input
                                         ),
                                         bokeh.layouts.row(
                                             offset_text_feature_color, bt_open_link

--- a/yomix/plotting/__init__.py
+++ b/yomix/plotting/__init__.py
@@ -1,3 +1,3 @@
-from .figure import main_figure
+from .figure import main_figure, check_obs_field
 from .legend import setup_legend
 from .features import color_by_feature_value

--- a/yomix/plotting/figure.py
+++ b/yomix/plotting/figure.py
@@ -17,10 +17,15 @@ import matplotlib
 import matplotlib.pyplot as plt
 from pathlib import Path
 
+MAX_UNIQUE_VALUES = 50
+MAX_UNIQUE_RATIO = 0.5
+
+def check_obs_field(xd, field):
+    return len(xd.obs[field].unique()) < MAX_UNIQUE_VALUES and len(xd.obs[field].unique())/xd.X.shape[0] < MAX_UNIQUE_RATIO
 
 def main_figure(adata, embedding_key, width=900, height=600, title=""):
 
-    obs_string = list(adata.obs.select_dtypes("category").keys())
+    obs_string = [x for x in list(adata.obs.select_dtypes("category").keys()) if check_obs_field(adata, x)]
     obs_numerical = list(adata.obs.select_dtypes(np.number).keys())
 
     embedding_size = adata.obsm[embedding_key].shape[1]

--- a/yomix/plotting/legend.py
+++ b/yomix/plotting/legend.py
@@ -311,6 +311,10 @@ def setup_legend(
     select_color_by = bokeh.models.Select(
         title="Color by ", value="", options=menu, width=235
     )
+    tooltip = bokeh.models.Tooltip(
+        content="Fields with a number of different unique items greater than 50 \n or greater than half the number of samples will be ignored ", position="right"
+    )
+    help_button = bokeh.models.HelpButton(tooltip=tooltip, margin=(21, 0, 3, 0))
 
     select_color_by.on_change(
         "value",
@@ -327,4 +331,4 @@ def setup_legend(
         ),
     )
 
-    return select_color_by, hidden_text_label_column, hidden_legend_width
+    return select_color_by, help_button, hidden_text_label_column, hidden_legend_width


### PR DESCRIPTION
Created a function to check if an obs field, in the anndata file, doesn't have too many unique values. 
This function uses 2 max parameters that could be updated in the plotting/figure.py file.
The function is applied twice, first to set xd.uns['all_labels'] in __main__.py, then to set obs_string in figure.py