### PR TITLE
Add legend field header, restyle label buttons, and --dev auto-reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@ build/
 dist/
 *.egg-info/
 *.pyc
+.vscode/
+key
+key.pub
 

--- a/yomix/__main__.py
+++ b/yomix/__main__.py
@@ -20,6 +20,9 @@ from bokeh.application import Application
 from bokeh.server.server import Server
 from pathlib import Path
 import argparse
+import subprocess
+import sys
+import time
 
 __all__ = ("main",)
 
@@ -57,13 +60,58 @@ def main():
     parser.add_argument(
         "--example", action="store_true", help="use the example dataset"
     )
+    parser.add_argument(
+        "--dev", action="store_true", help="auto-reload server when source files change"
+    )
 
     args = parser.parse_args()
+
+    if args.dev:
+        watch_dir = Path(__file__).resolve().parent
+        forward_args = [a for a in sys.argv[1:] if a != "--dev"]
+
+        def get_mtimes():
+            result = {}
+            for f in watch_dir.rglob("*.py"):
+                try:
+                    result[str(f)] = f.stat().st_mtime
+                except OSError:
+                    pass
+            return result
+
+        def start_server():
+            return subprocess.Popen([sys.executable, "-m", "yomix"] + forward_args)
+
+        mtimes = get_mtimes()
+        proc = start_server()
+        print(f"[dev] Server started. Watching {watch_dir} for changes …", flush=True)
+        try:
+            while True:
+                time.sleep(1)
+                new_mtimes = get_mtimes()
+                changed = [
+                    Path(f).name
+                    for f in new_mtimes
+                    if new_mtimes[f] != mtimes.get(f)
+                ]
+                if changed:
+                    print(
+                        f"[dev] Changed: {', '.join(changed)} — restarting …",
+                        flush=True,
+                    )
+                    mtimes = new_mtimes
+                    proc.terminate()
+                    proc.wait()
+                    proc = start_server()
+        except KeyboardInterrupt:
+            print("[dev] Stopping.", flush=True)
+            proc.terminate()
+        return
 
     argument = args.example
 
     if argument:
-        filearg = Path(__file__).parent / "example" / "pbmc.h5ad"
+        filearg = (Path(__file__).resolve().parent / "example" / "pbmc.h5ad")
     else:
         assert (
             args.file is not None
@@ -85,3 +133,7 @@ def main():
 
         io_loop.add_callback(server.show, "/")
         io_loop.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/yomix/plotting/figure.py
+++ b/yomix/plotting/figure.py
@@ -268,7 +268,7 @@ def main_figure(
     nipy_spectral_colormap._segmentdata["blue"][-1] = (1.0, 0.5, 0.5)
     nipy_spectral_colormap._init()
     nipy_colors = [
-        matplotlib.colors.rgb2hex(plt.get_cmap("nipy_spectral")(i)) for i in range(256)
+        matplotlib.colors.rgb2hex(plt.get_cmap("nipy_spectral")(i / 255)) for i in range(256)
     ]
     viridis_colors = list(bokeh.palettes.Viridis256)
     custom_color_mapper = bokeh.models.LinearColorMapper(

--- a/yomix/plotting/figure.py
+++ b/yomix/plotting/figure.py
@@ -151,10 +151,8 @@ def main_figure(
         if not adata.obs[x].isnull().values.any()
     ]
     unique_dict = {elt: list(np.unique(adata.obs[elt])) for elt in everything}
-    # Initialize custom_label with its default value (but not in obs_string)
-    unique_dict["custom_label"] = ["unlabeled"]
-    obs_string = [x for x in unique_dict.keys() if check_obs_field(unique_dict, x) and x != "custom_label"]
-    obs_string_many = [x for x in unique_dict.keys() if x not in obs_string and x != "custom_label"]
+    obs_string = [x for x in unique_dict.keys() if check_obs_field(unique_dict, x)]
+    obs_string_many = [x for x in unique_dict.keys() if x not in obs_string]
     obs_numerical = [
         col
         for col in list(adata.obs.select_dtypes(np.number).keys())
@@ -236,8 +234,6 @@ def main_figure(
     data["highlighted_B"] = np.zeros(len(data["point_size"]), dtype=np.float32)
     data["line_color"] = -np.ones(len(data["point_size"]), dtype=np.float32)
     data["line_width"] = np.zeros(len(data["point_size"]), dtype=np.float32)
-    # Custom labels field for user-defined point labels
-    data["custom_label"] = np.full(len(data["point_size"]), "unlabeled", dtype=object)
 
     source = bokeh.models.ColumnDataSource(data=data)
 

--- a/yomix/plotting/legend.py
+++ b/yomix/plotting/legend.py
@@ -83,25 +83,7 @@ def setup_legend(
                 obsn=obs_numerical,
             ),
             code="""
-        // Handle custom_label field (user-defined labels)
-        if (this.value === 'custom_label') {
-            const data = source.data;
-            // Get unique values from the custom_label field
-            var unique = [...new Set(data['custom_label'])].sort();
-            udicts['custom_label'] = unique;
-            var l_values = new Array(unique.length).fill(0);
-            const step = 1./(Math.max(unique.length - 1, 1)) * 0.999999;
-            var l_values_dict = {};
-            l_values_dict[unique[0]] = -1.;
-            for (let i = 1; i < l_values.length; i++) {
-                l_values[i] = l_values[i-1] + step;
-                l_values_dict[unique[i]] = l_values[i]-1.;
-            }
-            for (let i = 0; i < data["color"].length; i++) {
-                data["color"][i] = l_values_dict[data['custom_label'][i]];
-            }
-            source.change.emit();
-        }
+        // Handle fields in the static categorical list.
         if (obss.includes(this.value)) {
             const data = source.data;
             var unique = udicts[this.value];
@@ -144,6 +126,28 @@ def setup_legend(
             }
             source.change.emit();
         }
+        // Handle user-created / dynamic fields not in any static list.
+        if (this.value !== ''
+                && !obss.includes(this.value)
+                && !obsm.includes(this.value)
+                && !obsn.includes(this.value)
+                && source.data[this.value] !== undefined) {
+            const data = source.data;
+            var unique = [...new Set(data[this.value])].sort();
+            udicts[this.value] = unique;
+            var l_values = new Array(unique.length).fill(0);
+            const step = 1./(Math.max(unique.length - 1, 1)) * 0.999999;
+            var l_values_dict = {};
+            l_values_dict[unique[0]] = -1.;
+            for (let i = 1; i < l_values.length; i++) {
+                l_values[i] = l_values[i-1] + step;
+                l_values_dict[unique[i]] = l_values[i]-1.;
+            }
+            for (let i = 0; i < data["color"].length; i++) {
+                data["color"][i] = l_values_dict[data[this.value][i]];
+            }
+            source.change.emit();
+        }
     """,
         ),
     )
@@ -180,8 +184,8 @@ def setup_legend(
     label_signature = bokeh.models.MultiSelect(
         title="Groups",
         options=options,
-        width=235,
-        max_width=235,
+        width=275,
+        max_width=275,
         width_policy="max",
         description=tooltip,
     )
@@ -244,15 +248,12 @@ def setup_legend(
             None
         """
         label_signature.visible = False
-        # Handle custom_label (user-defined labels) - treat like obs_s
-        if obs_col == 'custom_label' or obs_col in obs_s:
+        # Handle user-defined labels - treat like obs_s
+        if obs_col in obs_s:
             s_field.visible = False
             bokeh_plot.right = []
             htlc.value = obs_col
             htlcbis.value = obs_col
-            # For custom_label, always regenerate the legend (labels can change dynamically)
-            if obs_col == 'custom_label' and obs_col in legend_dict:
-                del legend_dict[obs_col]
             if obs_col in legend_dict:
                 legend_list = legend_dict[obs_col][0]
                 for legend in legend_list:
@@ -479,6 +480,26 @@ def setup_legend(
             bt_slider_range.step = (max_val - min_val) / 100.0
             bt_slider_range.visible = True
 
+    def trigger_legend_refresh(obs_col: str) -> None:
+        """Force a full legend rebuild for *obs_col*, clearing any cached entry first."""
+        if obs_col in legend_dict:
+            del legend_dict[obs_col]
+        redefine_custom_legend(
+            pb_plot,
+            hidden_text_label_search,
+            hidden_text_label_column,
+            hidden_text_label_column_bis,
+            hidden_legend_width,
+            select_field,
+            obs_col,
+            legend_dict,
+            resize_width_input,
+            obs_string,
+            obs_string_many,
+            obs_numerical,
+            bt_slider_range,
+        )
+
     hidden_text_label_search = bokeh.models.TextInput(
         value="", title="Label search", name="hidden_text_label_search", width=999
     )
@@ -588,8 +609,9 @@ def setup_legend(
         position="right",
     )
 
-    # Add custom_label to menu for user-defined labels
-    menu = ["custom_label"] + obs_string + obs_string_many + obs_numerical
+    # Build the initial menu from existing obs fields only; user-created
+    # fields are added dynamically as the user creates them.
+    menu = obs_string + obs_string_many + obs_numerical
     select_color_by = bokeh.models.Select(
         title="Color by (select field):",
         value="",
@@ -623,4 +645,5 @@ def setup_legend(
         hidden_legend_width,
         select_field,
         label_signature,
+        trigger_legend_refresh,
     )

--- a/yomix/plotting/legend.py
+++ b/yomix/plotting/legend.py
@@ -345,6 +345,7 @@ def setup_legend(
                         legend.items[i].renderers[0].js_on_change("change:muted", cb_js)
                     legend.label_text_font = "Helvetica"
                     if iteration == 1:
+                        legend.title = obs_col
                         label_font_size = legend.label_text_font_size
                         # It's a string like '13px' so need to int-ify it:
                         label_font_size = int(label_font_size[:-2])
@@ -358,10 +359,15 @@ def setup_legend(
                         font.getlength(x.label["value"]) for x in legend.items
                     ]
                     max_label_width = max(all_label_width)
+                    title_width = (
+                        font.getlength(legend.title)
+                        if legend.title
+                        else 0
+                    )
                     width_increment = (
                         legend.border_line_width
                         + legend.glyph_width
-                        + max_label_width
+                        + max(max_label_width, title_width - legend.glyph_width - 14)
                         + 14
                     )
                     legend_width += width_increment

--- a/yomix/server/server.py
+++ b/yomix/server/server.py
@@ -23,7 +23,8 @@ from bokeh.models import TabPanel, Tabs
 from yomix.tools.download import (
     download_selected_button,
     csv_load_button,
-    add_label_button,
+    relabel_selection_button,
+    create_new_field_button,
     save_labels_button,
     load_labels_button,
 )
@@ -225,7 +226,7 @@ def gen_modify_doc_xd(
             bt_select_embedding = bokeh.models.Select(
                 title="Select embedding (.obsm field)",
                 value=embedding_key,
-                width=235,
+                width=275,
                 options=[(k, k) for k in list_ok_embed_keys],
                 name="bt_select_embedding",
             )
@@ -287,6 +288,7 @@ def gen_modify_doc_xd(
                     hidden_legend_width,
                     select_field,
                     label_signature,
+                    trigger_legend_refresh,
                 ) = yomix.plotting.setup_legend(
                     points_bokeh_plot,
                     obs_string,
@@ -399,9 +401,16 @@ def gen_modify_doc_xd(
                 source = scatter.data_source
                 download_button = download_selected_button(source, original_keys)
                 load_button = csv_load_button(source)
-                label_input, label_button = add_label_button(source, select_color_by, unique_dict)
-                save_labels_btn = save_labels_button(source)
-                hidden_labels_input, load_labels_btn = load_labels_button(source, select_color_by, unique_dict)
+                hidden_relabel, relabel_btn = relabel_selection_button(
+                    source, select_color_by, unique_dict, obs_string, trigger_legend_refresh
+                )
+                hidden_create_field, create_field_btn = create_new_field_button(
+                    source, select_color_by, unique_dict, obs_string, trigger_legend_refresh
+                )
+                save_labels_btn = save_labels_button(source, select_color_by)
+                hidden_labels_input, load_labels_btn = load_labels_button(
+                    source, select_color_by, unique_dict, obs_string, trigger_legend_refresh
+                )
 
                 p = bokeh.layouts.row(
                     bokeh.layouts.column(
@@ -416,9 +425,11 @@ def gen_modify_doc_xd(
                             bt_nothing,
                         ),
                         bokeh.layouts.row(download_button, load_button),
-                        label_input,
-                        bokeh.layouts.row(label_button, save_labels_btn),
-                        bokeh.layouts.row(load_labels_btn, hidden_labels_input),
+                        bokeh.layouts.row(relabel_btn, create_field_btn),
+                        bokeh.layouts.row(save_labels_btn, load_labels_btn),
+                        hidden_relabel,
+                        hidden_create_field,
+                        hidden_labels_input,
                         bokeh.layouts.row(bt_sign1, help1),
                         bokeh.layouts.row(bt_sign2, help2),
                         bokeh.layouts.row(bt_sign3, help3),

--- a/yomix/tools/download.py
+++ b/yomix/tools/download.py
@@ -6,6 +6,7 @@
 
 from bokeh.models import Button, CustomJS
 import bokeh.models
+import numpy as np
 
 
 def csv_load_button(
@@ -87,70 +88,280 @@ def csv_load_button(
     return button
 
 
-def add_label_button(
+def relabel_selection_button(
     source: bokeh.models.ColumnDataSource,
     select_color_by: bokeh.models.Select,
     unique_dict: dict,
+    obs_string: list,
+    trigger_legend_refresh,
 ) -> tuple[bokeh.models.TextInput, bokeh.models.Button]:
     """
-    Create a text input and button to assign a custom label to selected points.
+    Create a button that pops up a dialog to (re)label selected points
+    within the currently active "Color by" field.
 
-    The text input accepts the desired label name; clicking the button
-    applies it to all currently selected points via a server-side callback,
-    so the data update and legend rebuild are always in sync (no race
-    conditions between client-side patches and server-side callbacks).
-
-    The labels are stored in the ``"custom_label"`` field of the data
-    source and can be visualised via the "Color by" dropdown menu.
+    The popup asks for a label name and the target field, then applies the
+    label server-side (replacing any previous assignment of that label name
+    so the selection is always an exact replacement, not an addition).
+    Colors and the legend are refreshed automatically.
 
     Args:
         source : bokeh.models.ColumnDataSource
             Data source containing the data points.
         select_color_by : bokeh.models.Select
-            The "Color by" dropdown menu.
+            The "Color by" dropdown — its current value determines which
+            field is being labelled.
         unique_dict : dict
             Dictionary mapping field names to their unique values.
+        obs_string : list
+            Mutable list of categorical obs field names (user-created fields
+            are appended here so the legend handles them).
+        trigger_legend_refresh : callable
+            Callable ``(field_name: str) -> None`` that clears the legend
+            cache for *field_name* and rebuilds the legend widgets.
 
     Returns:
         Tuple containing:
-            - **label_input** (:class:`bokeh.models.TextInput`): Text input for the label name.
+            - **hidden_relay** (:class:`bokeh.models.TextInput`): Invisible
+              relay widget (must be in the document layout).
             - **button** (:class:`bokeh.models.Button`): "(Re)label selection" button.
     """
 
-    label_input = bokeh.models.TextInput(
-        placeholder="Enter label name...",
-        width=235,
-    )
+    hidden_relay = bokeh.models.TextInput(value="", visible=False, width=1)
 
-    button = Button(label="(Re)label selection", button_type="warning", width=120)
-
-    def apply_label():
-        label_name = label_input.value.strip()
-        if not label_name:
+    def apply_relabel(attr, old, new):
+        if not new or "|" not in new:
+            return
+        field, label_name = new.split("|", 1)
+        if field not in source.data:
+            hidden_relay.value = ""
             return
         inds = list(source.selected.indices)
         if not inds:
+            hidden_relay.value = ""
             return
 
-        # Patch the data source server-side so the legend rebuild that follows
-        # always reads the already-updated data (no client→server race condition).
-        source.patch({"custom_label": [(i, label_name) for i in inds]})
+        current_labels = list(source.data[field])
 
-        # Refresh unique_dict so redefine_custom_legend sees the new label set.
-        unique_dict["custom_label"] = sorted(set(source.data["custom_label"].tolist()))
+        # Replace semantics: reset all points that already carry this label
+        # to "unlabeled", then assign the new selection.
+        for i, lbl in enumerate(current_labels):
+            if lbl == label_name:
+                current_labels[i] = "unlabeled"
+        for i in inds:
+            current_labels[i] = label_name
 
-        # Ensure 'custom_label' is in the dropdown options.
-        if "custom_label" not in list(select_color_by.options):
-            select_color_by.options = ["custom_label"] + list(select_color_by.options)
+        new_unique = sorted(set(current_labels))
+        unique_dict[field] = new_unique
 
-        # Trigger legend rebuild.  Toggle away first so on_change fires even
-        # when the dropdown was already showing 'custom_label'.
-        if select_color_by.value == "custom_label":
-            select_color_by.value = ""
-        select_color_by.value = "custom_label"
+        # Compute colors directly in Python so the scatter plot updates
+        # immediately without depending on a JS round-trip.
+        n = len(new_unique)
+        step = 1.0 / max(n - 1, 1) * 0.999999
+        val_map = {new_unique[0]: -1.0}
+        for i in range(1, n):
+            val_map[new_unique[i]] = i * step - 1.0
+        new_colors = np.array(
+            [val_map.get(lbl, -1.0) for lbl in current_labels], dtype=np.float32
+        )
 
-    button.on_click(apply_label)
-    return label_input, button
+        new_data = dict(source.data)
+        new_data[field] = np.array(current_labels, dtype=object)
+        new_data["color"] = new_colors
+        source.data = new_data
+
+        # Rebuild legend widgets for this field.
+        trigger_legend_refresh(field)
+
+        # Ensure the dropdown reflects the active field.
+        if field not in list(select_color_by.options):
+            select_color_by.options = [field] + list(select_color_by.options)
+        if select_color_by.value != field:
+            select_color_by.value = field
+
+        hidden_relay.value = ""
+
+    hidden_relay.on_change("value", apply_relabel)
+
+    button = Button(label="(Re)label selection", button_type="warning", width=135)
+
+    js_callback = CustomJS(
+        args=dict(relay=hidden_relay, color_by=select_color_by),
+        code="""
+        const currentField = color_by.value;
+        if (!currentField) {
+            alert('Please select a "Color by" field first.');
+            return;
+        }
+
+        const overlay = document.createElement('div');
+        overlay.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;'
+            + 'background:rgba(0,0,0,0.45);z-index:9999;'
+            + 'display:flex;align-items:center;justify-content:center;';
+
+        const box = document.createElement('div');
+        box.style.cssText = 'background:#fff;padding:22px 24px;border-radius:8px;'
+            + 'min-width:420px;font-family:sans-serif;'
+            + 'box-shadow:0 4px 24px rgba(0,0,0,0.28);';
+        box.innerHTML =
+            '<p style="margin:0 0 12px;font-size:14px">'
+            + '<b>Name selection:</b>&nbsp;'
+            + '<input id="ym_label_input" type="text" '
+            + 'style="width:200px;padding:4px 6px;font-size:14px;'
+            + 'border:1px solid #ccc;border-radius:3px;">'
+            + '</p>'
+            + '<p style="margin:0 0 18px;font-size:13px">'
+            + 'Are you sure you want to label this selection inside '
+            + '<b>' + currentField + '</b>?'
+            + '</p>'
+            + '<button id="ym_yes" style="background:#28a745;color:#fff;border:none;'
+            + 'padding:7px 20px;cursor:pointer;border-radius:4px;'
+            + 'margin-right:10px;font-size:13px;">YES</button>'
+            + '<button id="ym_no" style="background:#dc3545;color:#fff;border:none;'
+            + 'padding:7px 20px;cursor:pointer;border-radius:4px;font-size:13px;">NO</button>';
+
+        overlay.appendChild(box);
+        document.body.appendChild(overlay);
+        const inp = box.querySelector('#ym_label_input');
+        inp.focus();
+
+        box.querySelector('#ym_yes').onclick = () => {
+            const labelName = inp.value.trim();
+            if (!labelName) { alert('Please enter a label name.'); return; }
+            document.body.removeChild(overlay);
+            relay.value = currentField + '|' + labelName;
+        };
+        box.querySelector('#ym_no').onclick = () => {
+            document.body.removeChild(overlay);
+        };
+        inp.onkeydown = (e) => {
+            if (e.key === 'Enter') box.querySelector('#ym_yes').click();
+            if (e.key === 'Escape') box.querySelector('#ym_no').click();
+        };
+        """,
+    )
+
+    button.js_on_click(js_callback)
+    return hidden_relay, button
+
+
+def create_new_field_button(
+    source: bokeh.models.ColumnDataSource,
+    select_color_by: bokeh.models.Select,
+    unique_dict: dict,
+    obs_string: list,
+    trigger_legend_refresh,
+) -> tuple[bokeh.models.TextInput, bokeh.models.Button]:
+    """
+    Create a button that pops up a dialog to create a new labelling field.
+
+    The popup asks for a field name, then adds that field to the data source
+    (initialised to ``"unlabeled"`` for all points), registers it with the
+    legend system, and switches the "Color by" dropdown to it.
+
+    Args:
+        source : bokeh.models.ColumnDataSource
+            Data source to extend with the new field.
+        select_color_by : bokeh.models.Select
+            The "Color by" dropdown — will be switched to the new field.
+        unique_dict : dict
+            Dictionary mapping field names to their unique values.
+        obs_string : list
+            Mutable list of categorical obs field names — the new field is
+            appended here so the legend system treats it as categorical.
+        trigger_legend_refresh : callable
+            Callable ``(field_name: str) -> None`` that rebuilds the legend
+            for a given field.
+
+    Returns:
+        Tuple containing:
+            - **hidden_relay** (:class:`bokeh.models.TextInput`): Invisible
+              relay widget (must be in the document layout).
+            - **button** (:class:`bokeh.models.Button`): "Create new field" button.
+    """
+
+    hidden_relay = bokeh.models.TextInput(value="", visible=False, width=1)
+
+    def create_field(attr, old, new):
+        if not new:
+            return
+        field_name = new.strip()
+        if not field_name:
+            hidden_relay.value = ""
+            return
+
+        n = len(source.data["color"])
+        new_field = np.full(n, "unlabeled", dtype=object)
+
+        new_data = dict(source.data)
+        new_data[field_name] = new_field
+        source.data = new_data
+
+        unique_dict[field_name] = ["unlabeled"]
+
+        if field_name not in obs_string:
+            obs_string.append(field_name)
+
+        if field_name not in list(select_color_by.options):
+            select_color_by.options = [field_name] + list(select_color_by.options)
+
+        # Build legend and switch view to the new field.
+        trigger_legend_refresh(field_name)
+        select_color_by.value = field_name
+
+        hidden_relay.value = ""
+
+    hidden_relay.on_change("value", create_field)
+
+    button = Button(label="Create new field", button_type="primary", width=135)
+
+    js_callback = CustomJS(
+        args=dict(relay=hidden_relay),
+        code="""
+        const overlay = document.createElement('div');
+        overlay.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;'
+            + 'background:rgba(0,0,0,0.45);z-index:9999;'
+            + 'display:flex;align-items:center;justify-content:center;';
+
+        const box = document.createElement('div');
+        box.style.cssText = 'background:#fff;padding:22px 24px;border-radius:8px;'
+            + 'min-width:320px;font-family:sans-serif;'
+            + 'box-shadow:0 4px 24px rgba(0,0,0,0.28);';
+        box.innerHTML =
+            '<p style="margin:0 0 18px;font-size:14px">'
+            + '<b>Name new field:</b>&nbsp;'
+            + '<input id="ym_field_input" type="text" '
+            + 'style="width:180px;padding:4px 6px;font-size:14px;'
+            + 'border:1px solid #ccc;border-radius:3px;">'
+            + '</p>'
+            + '<button id="ym_ok" style="background:#28a745;color:#fff;border:none;'
+            + 'padding:7px 20px;cursor:pointer;border-radius:4px;'
+            + 'margin-right:10px;font-size:13px;">OK</button>'
+            + '<button id="ym_cancel" style="background:#dc3545;color:#fff;border:none;'
+            + 'padding:7px 20px;cursor:pointer;border-radius:4px;font-size:13px;">Cancel</button>';
+
+        overlay.appendChild(box);
+        document.body.appendChild(overlay);
+        const inp = box.querySelector('#ym_field_input');
+        inp.focus();
+
+        box.querySelector('#ym_ok').onclick = () => {
+            const fieldName = inp.value.trim();
+            if (!fieldName) { alert('Please enter a field name.'); return; }
+            document.body.removeChild(overlay);
+            relay.value = fieldName;
+        };
+        box.querySelector('#ym_cancel').onclick = () => {
+            document.body.removeChild(overlay);
+        };
+        inp.onkeydown = (e) => {
+            if (e.key === 'Enter') box.querySelector('#ym_ok').click();
+            if (e.key === 'Escape') box.querySelector('#ym_cancel').click();
+        };
+        """,
+    )
+
+    button.js_on_click(js_callback)
+    return hidden_relay, button
 
 
 def download_selected_button(
@@ -210,51 +421,63 @@ def download_selected_button(
 
 def save_labels_button(
     source: bokeh.models.ColumnDataSource,
+    select_color_by: bokeh.models.Select,
 ) -> bokeh.models.Button:
     """
-    Create a button to save custom labels to a CSV file.
+    Create a button to save the currently active field's labels to a CSV file.
+
+    The saved CSV has the format ``name\\t<field_name>`` so it can be reloaded
+    by :func:`load_labels_button` into the correct field.
 
     Args:
         source : bokeh.models.ColumnDataSource
-            Data source containing the custom_label field.
+            Data source containing the label fields.
+        select_color_by : bokeh.models.Select
+            The "Color by" dropdown — its current value names the field to save.
 
     Returns:
         ``Save labels`` button (:class:`bokeh.models.Button`) :
-            On click, it downloads all points with their custom labels as a CSV file.
+            On click, downloads all points with their labels as a TSV/CSV file.
     """
 
-    button = Button(label="Save labels", button_type="primary", width=112)
+    button = Button(label="Save labels", button_type="success", width=112)
     button.js_on_click(
         CustomJS(
-            args=dict(source=source),
+            args=dict(source=source, color_by=select_color_by),
             code="""
-        const data = source.data;
-        const names = data['name'];
-        const labels = data['custom_label'];
-        
-        // Check if there are any non-default labels
-        const hasLabels = labels.some(l => l !== 'unlabeled');
-        if (!hasLabels) {
-            alert('No custom labels have been assigned yet!');
+        const field = color_by.value;
+        if (!field) {
+            alert('Please select a "Color by" field to save.');
             return;
         }
-        
-        let csv = 'name\\tcustom_label\\n';
+        const data = source.data;
+        const labels = data[field];
+        if (!labels) {
+            alert('Selected field not found in data.');
+            return;
+        }
+        const names = data['name'];
+        const hasContent = labels.some(
+            l => l !== 'unlabeled' && l !== undefined && l !== null && l !== ''
+        );
+        if (!hasContent) {
+            alert('No labels have been assigned in this field yet!');
+            return;
+        }
+        let csv = 'name\\t' + field + '\\n';
         for (let i = 0; i < names.length; i++) {
             csv += names[i] + '\\t' + labels[i] + '\\n';
         }
-        
         const blob = new Blob([csv], { type: 'text/csv' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = 'custom_labels.csv';
+        a.download = field + '_labels.csv';
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
-        
-        alert('Labels saved to custom_labels.csv');
+        alert('Labels saved to ' + field + '_labels.csv');
     """,
         )
     )
@@ -265,23 +488,34 @@ def load_labels_button(
     source: bokeh.models.ColumnDataSource,
     select_color_by: bokeh.models.Select,
     unique_dict: dict,
+    obs_string: list,
+    trigger_legend_refresh,
 ) -> tuple[bokeh.models.TextInput, bokeh.models.Button]:
     """
-    Create a button to load custom labels from a CSV file.
+    Create a button to load labels from a CSV file into the data source.
 
-    The button opens a file picker in the browser.  The selected file's
-    raw text is relayed to a hidden :class:`~bokeh.models.TextInput` which
-    triggers a server-side Python callback that patches the data source and
-    rebuilds the legend — avoiding the race condition that arises when both
-    steps are performed purely client-side.
+    The CSV must have the format ``name\\t<field_name>`` (tab-separated, first
+    line is the header).  If the named field does not yet exist it is created
+    and initialised to ``"unlabeled"`` before the loaded values are applied.
+
+    The button opens a file picker in the browser.  The selected file's raw
+    text is relayed to a hidden :class:`~bokeh.models.TextInput` which
+    triggers a server-side Python callback that updates the data source,
+    recomputes colors, and rebuilds the legend — avoiding the race condition
+    that arises when these steps are performed purely client-side.
 
     Args:
         source : bokeh.models.ColumnDataSource
             Data source to update with loaded labels.
         select_color_by : bokeh.models.Select
-            The "Color by" dropdown menu.
+            The "Color by" dropdown — will be switched to the loaded field.
         unique_dict : dict
             Dictionary mapping field names to their unique values.
+        obs_string : list
+            Mutable list of categorical obs field names — new fields are
+            appended here so the legend handles them.
+        trigger_legend_refresh : callable
+            Callable ``(field_name: str) -> None`` that rebuilds the legend.
 
     Returns:
         Tuple containing:
@@ -296,32 +530,67 @@ def load_labels_button(
         if not new:
             return
         lines = new.strip().split("\n")
+        if not lines:
+            hidden_csv_input.value = ""
+            return
+        # Read field name from the header's second column.
+        header_parts = lines[0].split("\t")
+        if len(header_parts) < 2:
+            hidden_csv_input.value = ""
+            return
+        field_name = header_parts[1].strip()
+
+        n = len(source.data["color"])
         name_to_idx = {name: i for i, name in enumerate(source.data["name"])}
-        patches = []
+
+        # Start from existing labels or a blank slate.
+        if field_name in source.data:
+            old_labels = list(source.data[field_name])
+        else:
+            old_labels = ["unlabeled"] * n
+
         for line in lines[1:]:  # skip header
             parts = line.split("\t")
             if len(parts) >= 2:
                 name, label = parts[0], parts[1].strip()
                 if name in name_to_idx:
-                    patches.append((name_to_idx[name], label))
-        if patches:
-            source.patch({"custom_label": patches})
-            unique_dict["custom_label"] = sorted(
-                set(source.data["custom_label"].tolist())
-            )
-            if "custom_label" not in list(select_color_by.options):
-                select_color_by.options = ["custom_label"] + list(
-                    select_color_by.options
-                )
-            if select_color_by.value == "custom_label":
-                select_color_by.value = ""
-            select_color_by.value = "custom_label"
+                    old_labels[name_to_idx[name]] = label
+
+        new_labels = np.array(old_labels, dtype=object)
+        new_unique = sorted(set(old_labels))
+        unique_dict[field_name] = new_unique
+
+        # Compute colors in Python for an immediate, reliable update.
+        n_u = len(new_unique)
+        step = 1.0 / max(n_u - 1, 1) * 0.999999
+        val_map = {new_unique[0]: -1.0}
+        for i in range(1, n_u):
+            val_map[new_unique[i]] = i * step - 1.0
+        new_colors = np.array(
+            [val_map.get(lbl, -1.0) for lbl in old_labels], dtype=np.float32
+        )
+
+        new_data = dict(source.data)
+        new_data[field_name] = new_labels
+        new_data["color"] = new_colors
+        source.data = new_data
+
+        if field_name not in obs_string:
+            obs_string.append(field_name)
+
+        if field_name not in list(select_color_by.options):
+            select_color_by.options = [field_name] + list(select_color_by.options)
+
+        # Rebuild legend and switch view.
+        trigger_legend_refresh(field_name)
+        select_color_by.value = field_name
+
         # Reset relay so the same file can be reloaded if needed.
         hidden_csv_input.value = ""
 
     hidden_csv_input.on_change("value", process_csv)
 
-    button = Button(label="Load labels", button_type="primary", width=112)
+    button = Button(label="Load labels", button_type="success", width=112)
 
     callback = CustomJS(
         args=dict(relay=hidden_csv_input),

--- a/yomix/tools/download.py
+++ b/yomix/tools/download.py
@@ -123,7 +123,7 @@ def relabel_selection_button(
         Tuple containing:
             - **hidden_relay** (:class:`bokeh.models.TextInput`): Invisible
               relay widget (must be in the document layout).
-            - **button** (:class:`bokeh.models.Button`): "(Re)label selection" button.
+            - **button** (:class:`bokeh.models.Button`): "Label selection" button.
     """
 
     hidden_relay = bokeh.models.TextInput(value="", visible=False, width=1)
@@ -182,7 +182,7 @@ def relabel_selection_button(
 
     hidden_relay.on_change("value", apply_relabel)
 
-    button = Button(label="(Re)label selection", button_type="warning", width=135)
+    button = Button(label="Label selection", button_type="warning", width=112)
 
     js_callback = CustomJS(
         args=dict(relay=hidden_relay, color_by=select_color_by),
@@ -312,7 +312,7 @@ def create_new_field_button(
 
     hidden_relay.on_change("value", create_field)
 
-    button = Button(label="Create new field", button_type="primary", width=135)
+    button = Button(label="Create new field", button_type="warning", width=112)
 
     js_callback = CustomJS(
         args=dict(relay=hidden_relay),

--- a/yomix/tools/signatures.py
+++ b/yomix/tools/signatures.py
@@ -511,8 +511,8 @@ def signature_buttons(
     multiselect_signature = bokeh.models.MultiSelect(
         title="Signature #0",
         options=options,
-        width=235,
-        max_width=235,
+        width=275,
+        max_width=275,
         size=20,
         width_policy="max",
     )


### PR DESCRIPTION
## Summary

This PR enhances the interactive labeling UI and fixes several visual/functional issues.

### Changes

**`yomix/plotting/legend.py`**
- Display the current obs field name as a title/header on the legend panel when a custom label field is active.
- Widen the legend panel automatically to accommodate the title text, using `PIL.ImageFont` for accurate text measurement.

**`yomix/tools/download.py`**
- Renamed button label from `(Re)label selection` → `Label selection`.
- Changed `Create new field` button color from blue (`primary`) to yellow (`warning`).
- Reduced width of both `Label selection` and `Create new field` buttons from 135 → 112 px.

**`yomix/__main__.py`**
- Added `--dev` flag that watches all `.py` files in the package directory and automatically restarts the Bokeh server when any file changes (auto-reload for development).
- Fixed `filearg` path resolution to use `Path(__file__).resolve().parent` for robust handling regardless of the current working directory.
- Added `if __name__ == "__main__": main()` guard so `python -m yomix` correctly invokes `main()`.

**`yomix/plotting/figure.py`**
- Fixed `nipy_spectral` colormap sampling: changed `i` → `i / 255` when calling `plt.get_cmap("nipy_spectral")(...)`, ensuring all 256 sampled colors are evenly spread across the full spectrum instead of most values collapsing to the same pink/rose hue.

## Test plan

- [ ] Launch `yomix --example` and confirm the scatter plot renders with distinct colors for each label category (no unexpected pink/rose for non-unlabeled points).
- [ ] Select points and use `Label selection` to assign a custom label; verify the legend header updates to show the field name.
- [ ] Use `Create new field` to create a new label field; verify the yellow button and updated legend header.
- [ ] Run `yomix --example --dev`, edit a source file, and confirm the server restarts automatically.